### PR TITLE
Remove tomates from omelette

### DIFF
--- a/config/dishes.txt
+++ b/config/dishes.txt
@@ -3,7 +3,7 @@ Chicken and chips and chili
 Aldente spaghetti with tomatosauce and mushrooms and chili
 Lamb and cabbage with mushrooms and carrots
 Veggieburger with cheese add chili
-Omelette with bacon and mushrooms and tomatoes
+Omelette with bacon and mushrooms
 Fajitas with chicken and red peppers
 Meat balls in brown sauce with salad and potatos
 Tomato soup with macaroni and egg


### PR DESCRIPTION
The tomatoes makes the omelette "soggy" as exlained in issue #124 

Discussed and supported by Olve