### PR TITLE
Include Brigadeiro

### DIFF
--- a/config/desserts.txt
+++ b/config/desserts.txt
@@ -16,3 +16,4 @@ Strawberry icecream with strawberries
 Blackforest cake
 Queen Maud pudding
 Brownie Cake
+Brazilian Chocolate truffle (Brigadeiro)


### PR DESCRIPTION
Include Brigadeiro, a Brazilian Chocolate truffle. 
Aline also wanted to include it in the past.