### PR TITLE
Fix typo "Pasta al Pesto"

### DIFF
--- a/config/dishes.txt
+++ b/config/dishes.txt
@@ -15,7 +15,7 @@ Porridge
 Pan-fried red mullet with chili
 Paella without pineapples but with chili
 Big fat burger with onion rings
-Pasta pesto
+Pasta al pesto
 Vegetable soup
 Dumplings with raisins
 Eggs and bacon and beans and chili


### PR DESCRIPTION
Is an Italian dish so it requires "al" preposition